### PR TITLE
Only consume body when http code doesn't cause immediate rejection

### DIFF
--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -66,15 +66,18 @@ module Helper =
         let eitherUnitOr = eitherUnit responseResolver.Value
 
         promise {
-            let! body = response.text()
-            let result =
+            let! result =
                 if response.Ok then
-                    eitherUnitOr <| fun () ->
-                        match decode body with
-                        | Ok value -> Ok value
-                        | Error msg -> DecodingFailed msg |> Error
+                    promise {
+                        let! body = response.text()
+                        return eitherUnitOr <| fun () ->
+                            match decode body with
+                            | Ok value -> Ok value
+                            | Error msg -> DecodingFailed msg |> Error
+                    }
                 else
                     FetchFailed response |> Error
+                    |> Promise.lift
             return result
         }
 
@@ -208,7 +211,7 @@ type Fetch =
     ///   * `System.Exception` - Contains information explaining why the request failed
     ///
     static member get<'Data, 'Response> (url: string, ?data: 'Data, ?properties: RequestProperties list,
-                                         ?headers: HttpRequestHeaders list, ?isCamelCase: bool, 
+                                         ?headers: HttpRequestHeaders list, ?isCamelCase: bool,
                                          ?extra: ExtraCoders, ?decoder: Decoder<'Response>,
                                          [<Inject>] ?responseResolver: ITypeResolver<'Response>,
                                          [<Inject>] ?dataResolver: ITypeResolver<'Data>) =
@@ -275,7 +278,7 @@ type Fetch =
     ///   * `System.Exception` - Contains information explaining why the request failed
     ///
     static member post<'Data, 'Response> (url: string, ?data: 'Data, ?properties: RequestProperties list,
-                                          ?headers: HttpRequestHeaders list, ?isCamelCase: bool, 
+                                          ?headers: HttpRequestHeaders list, ?isCamelCase: bool,
                                           ?extra: ExtraCoders, ?decoder: Decoder<'Response>,
                                           [<Inject>] ?responseResolver: ITypeResolver<'Response>,
                                           [<Inject>] ?dataResolver: ITypeResolver<'Data>) =
@@ -344,7 +347,7 @@ type Fetch =
     ///   * `System.Exception` - Contains information explaining why the request failed
     ///
     static member put<'Data, 'Response> (url: string, ?data: 'Data, ?properties: RequestProperties list,
-                                         ?headers: HttpRequestHeaders list, ?isCamelCase: bool, 
+                                         ?headers: HttpRequestHeaders list, ?isCamelCase: bool,
                                          ?extra: ExtraCoders, ?decoder: Decoder<'Response>,
                                          [<Inject>] ?responseResolver: ITypeResolver<'Response>,
                                          [<Inject>] ?dataResolver: ITypeResolver<'Data>) =
@@ -413,7 +416,7 @@ type Fetch =
     ///   * `System.Exception` - Contains information explaining why the request failed
     ///
     static member patch<'Data, 'Response> (url: string, ?data: 'Data, ?properties: RequestProperties list,
-                                           ?headers: HttpRequestHeaders list, ?isCamelCase: bool, 
+                                           ?headers: HttpRequestHeaders list, ?isCamelCase: bool,
                                            ?extra: ExtraCoders, ?decoder: Decoder<'Response>,
                                            [<Inject>] ?responseResolver: ITypeResolver<'Response>,
                                            [<Inject>] ?dataResolver: ITypeResolver<'Data>) =

--- a/tests/fake-error-report.js
+++ b/tests/fake-error-report.js
@@ -1,0 +1,5 @@
+export default function(req, res) {
+    res.status(400).jsonp({
+        reason: "This always fails."
+    });
+}


### PR DESCRIPTION
- To give consuming clients the chance to parse the body themselves for
  non-success status codes. This is especially important to extract
  additional information about errors encoded in the response bodies.